### PR TITLE
Adding embedded type definition file.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,27 @@
+// Type definitions for ngraph.path v1.0.2
+// Project: https://github.com/anvaka/ngraph.path
+// Definitions by: Nathan Westlake <https://github.com/CorayThan>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+declare module "ngraph.path" {
+
+    import { Graph, Link, Node, NodeId } from "ngraph.graph"
+
+    interface PathFinderOptions {
+        oriented?: boolean
+        quitFast?: boolean
+        heuristic?: (from: NodeId, to: NodeId) => number
+        distance?: (from: NodeId, to: NodeId, link: Link) => number
+    }
+
+    interface PathFinder {
+        find: (from: NodeId, to: NodeId) => Node[]
+    }
+
+    export function aStar(graph: Graph, options?: PathFinderOptions): PathFinder
+
+    export function aGreedy(graph: Graph, options?: PathFinderOptions): PathFinder
+
+    export function nba(graph: Graph, options?: PathFinderOptions): PathFinder
+
+}


### PR DESCRIPTION
I created some type definition files for using your pathing library in a Typescript project, and wanted to see if we could embed them so others will have type definitions too, in the future.

I didn't update the version of the project, but obviously the version would need to be updated for a new NPM version as well.