### PR TITLE
Feat: Add support to handle blocked paths

### DIFF
--- a/a-star/a-greedy-star.js
+++ b/a-star/a-greedy-star.js
@@ -40,6 +40,9 @@ function aStarBi(graph, options) {
   // whether traversal should be considered over oriented graph.
   var oriented = options.oriented;
 
+  var blocked = options.blocked;
+  if (!blocked) blocked = defaultSettings.blocked;
+
   var heuristic = options.heuristic;
   if (!heuristic) heuristic = defaultSettings.heuristic;
 
@@ -179,6 +182,11 @@ function aStarBi(graph, options) {
 
       if (otherSearchState.closed) {
         // Already processed this node.
+        return;
+      }
+
+      if (blocked(otherSearchState.node, cameFrom.node, link)) {
+        // Path is blocked. Ignore this route
         return;
       }
 

--- a/a-star/a-star.js
+++ b/a-star/a-star.js
@@ -38,6 +38,9 @@ function aStarPathSearch(graph, options) {
   // whether traversal should be considered over oriented graph.
   var oriented = options.oriented;
 
+  var blocked = options.blocked;
+  if (!blocked) blocked = defaultSettings.blocked;
+
   var heuristic = options.heuristic;
   if (!heuristic) heuristic = defaultSettings.heuristic;
 
@@ -110,6 +113,11 @@ function aStarPathSearch(graph, options) {
         // Remember this node.
         openSet.push(otherSearchState);
         otherSearchState.open = 1;
+      }
+
+      if (blocked(otherNode, cameFrom.node, link)) {
+        // Path is blocked. Ignore this route
+        return;
       }
 
       var tentativeDistance = cameFrom.distanceToSource + distance(otherNode, cameFrom.node, link);

--- a/a-star/defaultSettings.js
+++ b/a-star/defaultSettings.js
@@ -7,6 +7,7 @@ module.exports = {
   // Path search settings
   heuristic: blindHeuristic,
   distance: constantDistance,
+  blocked: neverBlocked,
   compareFScore: compareFScore,
   NO_PATH: NO_PATH,
 
@@ -27,6 +28,10 @@ function blindHeuristic(/* a, b */) {
 
 function constantDistance(/* a, b */) {
   return 1;
+}
+
+function neverBlocked(/* a, b, c */) {
+  return false;
 }
 
 function compareFScore(a, b) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,6 +13,7 @@ declare module "ngraph.path" {
         quitFast?: boolean
         heuristic?: (from: Node<NodeData>, to: Node<NodeData>) => number
         distance?: (from: Node<NodeData>, to: Node<NodeData>, link: Link<LinkData>) => number
+        blocked?: (from: Node<NodeData>, to: Node<NodeData>, link: Link<LinkData>) => number
     }
 
     interface PathFinder<NodeData> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module "ngraph.path" {
         quitFast?: boolean
         heuristic?: (from: Node<NodeData>, to: Node<NodeData>) => number
         distance?: (from: Node<NodeData>, to: Node<NodeData>, link: Link<LinkData>) => number
-        blocked?: (from: Node<NodeData>, to: Node<NodeData>, link: Link<LinkData>) => number
+        blocked?: (from: Node<NodeData>, to: Node<NodeData>, link: Link<LinkData>) => boolean
     }
 
     interface PathFinder<NodeData> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ngraph.path",
       "version": "1.3.1",
       "license": "MIT",
       "devDependencies": {

--- a/test/a-star.js
+++ b/test/a-star.js
@@ -27,6 +27,49 @@ test('it can find weighted', t => {
   t.end();
 });
 
+test('A* does not follow blocked paths', t => {
+  let graph = createGraph();
+
+  graph.addLink('a', 'b', {blocked: true});
+  graph.addLink('a', 'c', {blocked: false});
+  graph.addLink('c', 'd', {blocked: false});
+  graph.addLink('b', 'd', {blocked: false});
+
+
+  var pathFinder = aStar(graph, {
+    blocked(a, b, link) {
+      return link.data.blocked;
+    }
+  });
+  let path = pathFinder.find('a', 'd');
+
+  t.equal(path[0].id, 'd', 'd is here');
+  t.equal(path[1].id, 'c', 'c is here');
+  t.equal(path[2].id, 'a', 'a is here');
+  t.end();
+});
+
+test('A* greedy does not follow blocked paths', t => {
+  let graph = createGraph();
+
+  graph.addLink('a', 'b', {blocked: true});
+  graph.addLink('a', 'c', {blocked: false});
+  graph.addLink('c', 'd', {blocked: false});
+  graph.addLink('b', 'd', {blocked: false});
+
+  var pathFinder = aGreedy(graph, {
+    blocked(a, b, link) {
+      return link.data.blocked;
+    }
+  });
+  let path = pathFinder.find('a', 'd');
+
+  t.equal(path[2].id, 'd', 'd is here');
+  t.equal(path[1].id, 'c', 'c is here');
+  t.equal(path[0].id, 'a', 'a is here');
+  t.end();
+});
+
 test('A* can find directed path', t => {
   let graph = createGraph();
 


### PR DESCRIPTION
The use case that precipitated this is a game where paths are temporarily blocked (i.e. door is closed/locked). This adds a configuration property to the Path Finder called `blocked` which is a Function that takes three parameters: the candidate destination Node, the from Node, and the Link between them. When the Function returns `true`, the path it blocked and is ignored as a valid candidate. 

The tests here are a bit contrived, using a property on the Link to indicate blocked or not, however, in my game the Function will query the game state to see whether the path is actually blocked or not.